### PR TITLE
fix #8

### DIFF
--- a/Rhino.Etl.Core/Infrastructure/SqlCommandSet.cs
+++ b/Rhino.Etl.Core/Infrastructure/SqlCommandSet.cs
@@ -113,9 +113,11 @@ namespace Rhino.Etl.Core.Infrastructure
         /// <param name="command"></param>
         private static void AssertHasParameters(SqlCommand command)
         {
-            if(command.Parameters.Count==0)
+            if (command.Parameters.Count == 0 &&
+                (RuntimeInfo.Version.Contains("2.0") || RuntimeInfo.Version.Contains("1.1")))
             {
-                throw new ArgumentException("A command in SqlCommandSet must have parameters. You can't pass hardcoded sql strings.");
+                throw new ArgumentException(
+                    "A command in SqlCommandSet must have parameters. You can't pass hardcoded sql strings.");
             }
         }
         

--- a/Rhino.Etl.Core/Operations/SqlBatchOperation.cs
+++ b/Rhino.Etl.Core/Operations/SqlBatchOperation.cs
@@ -38,7 +38,7 @@ namespace Rhino.Etl.Core.Operations
         /// Initializes a new instance of the <see cref="SqlBatchOperation"/> class.
         /// </summary>
         /// <param name="connectionStringName">Name of the connection string.</param>
-        public SqlBatchOperation(string connectionStringName)
+        protected SqlBatchOperation(string connectionStringName)
             : this(ConfigurationManager.ConnectionStrings[connectionStringName])
         {            
         }
@@ -47,7 +47,7 @@ namespace Rhino.Etl.Core.Operations
         /// Initializes a new instance of the <see cref="SqlBatchOperation"/> class.
         /// </summary>
         /// <param name="connectionStringSettings">The connection string settings to use.</param>
-        public SqlBatchOperation(ConnectionStringSettings connectionStringSettings)
+        protected SqlBatchOperation(ConnectionStringSettings connectionStringSettings)
             : base(connectionStringSettings)
         {
             base.paramPrefix = "@";
@@ -66,11 +66,12 @@ namespace Rhino.Etl.Core.Operations
             {
                 SqlCommandSet commandSet = null;
                 CreateCommandSet(connection, transaction, ref commandSet, timeout);
+
                 foreach (Row row in rows)
                 {
                     SqlCommand command = new SqlCommand();
                     PrepareCommand(row, command);
-                    if (command.Parameters.Count == 0) //workaround around a framework bug
+                    if (command.Parameters.Count == 0 && (RuntimeInfo.Version.Contains("2.0") || RuntimeInfo.Version.Contains("1.1"))) //workaround around a framework bug
                     {
                         Guid guid = Guid.NewGuid();
                         command.Parameters.AddWithValue(guid.ToString(), guid);

--- a/Rhino.Etl.Core/Rhino.Etl.Core.csproj
+++ b/Rhino.Etl.Core/Rhino.Etl.Core.csproj
@@ -122,12 +122,13 @@
     <Compile Include="Pipelines\PipelineExecutionException.cs" />
     <Compile Include="Pipelines\SingleThreadedNonCachedPipelineExecuter.cs" />
     <Compile Include="Pipelines\ThreadPoolPipelineExecuter.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Operations\SqlBulkInsertOperation.cs" />
     <Compile Include="Pipelines\SingleThreadedPipelineExecuter.cs" />
     <Compile Include="Exceptions\RhinoEtlException.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="QuackingDictionary.cs" />
     <Compile Include="Row.cs" />
+    <Compile Include="RuntimeInfo.cs" />
     <Compile Include="WithLoggingMixin.cs" />
   </ItemGroup>
   <ItemGroup>
@@ -150,6 +151,7 @@
       <Install>false</Install>
     </BootstrapperPackage>
   </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/Rhino.Etl.Core/RuntimeInfo.cs
+++ b/Rhino.Etl.Core/RuntimeInfo.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+
+namespace Rhino.Etl.Core
+{
+    internal static class RuntimeInfo
+    {
+        public static string Version
+        {
+            get
+            {
+                var asm = Assembly.GetEntryAssembly();
+                return asm.ImageRuntimeVersion;
+            }
+        }
+    }
+}


### PR DESCRIPTION
New class 'RuntimeInfo' has been added to get the Entry assembly's
runtime version. SqlBatchOperion.Execute has been changed to check the
runtime, and if it's 2.0 or below then apply the workaround for
framework bug. Tested with .net 4.0 and 4.5. Needs further testing in .net 3.5, 3, and 2.
For the tests I've built it with the provided build script.